### PR TITLE
refactored pom.xml to not use a parent pom as this adds additional wo…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,13 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.codehaus.sonar-plugins</groupId>
-    <artifactId>parent</artifactId>
-    <version>18</version>
-    <relativePath>../parent</relativePath>
-  </parent>
-
+  <groupId>org.codehaus.sonar-plugins</groupId>
   <artifactId>sonar-sonargraph-plugin</artifactId>
   <packaging>sonar-plugin</packaging>
   <version>3.4.3-SNAPSHOT</version>
@@ -59,9 +53,16 @@
 
   <dependencies>
     <dependency>
+	  <groupId>org.codehaus.sonar-plugins</groupId>
+	  <artifactId>parent</artifactId>
+      <version>18</version>
+	  <type>pom</type>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.sonar</groupId>
       <artifactId>sonar-plugin-api</artifactId>
       <version>${sonar.version}</version>
+	  <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.sonar</groupId>


### PR DESCRIPTION
refactored the parent pom declaration and made it a direct dependency. This would cut down on confusion of those who clone the repository and then try to build without have to create a parent directory and then have to fetch the pom and drop it into this folder.