### PR TITLE
Fix default report location

### DIFF
--- a/src/main/java/com/hello2morrow/sonarplugin/persistence/ReportFileReader.java
+++ b/src/main/java/com/hello2morrow/sonarplugin/persistence/ReportFileReader.java
@@ -48,7 +48,7 @@ import java.util.List;
 public class ReportFileReader implements IReportReader {
 
   private static final Logger LOG = LoggerFactory.getLogger(ReportFileReader.class);
-  private static final String REPORT_DIR = "sonargraph-sonar-plugin";
+  private static final String REPORT_DIR = "sonargraph";
   private static final String REPORT_NAME = "sonargraph-sonar-report.xml";
   private ReportContext report;
 


### PR DESCRIPTION
If I'm properly interpreting `javap`'s output for `com.hello2morrow.sonargraph.build.client.CreateReportInteraction`, then `sonargraph-build-client-8.8.0` is creating the report as `sonar/sonargraph-sonarqube-report.xml`.